### PR TITLE
Style improvements (tables, collapseblock) + minor things

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
     "publisher": "hadesarchitect",
     "displayName": "katapod",
     "repository": {
-        "url": "https://github.com/HadesArchitect/katapod"
+        "url": "https://github.com/DataStax-Academy/katapod"
     },
     "description": "",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": "Apache-2.0",
     "engines": {
         "vscode": "^1.64.0"

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -17,7 +17,7 @@ function createPanel(config: ConfigObject): vscode.WebviewPanel {
 	log("debug", "[createPanel] Creating WebViewPanel...");
 	return vscode.window.createWebviewPanel(
 		"datastax.katapod",
-		"DataStax Training Grounds",
+		"DataStax Hands-On Labs",
 		vscode.ViewColumn.One,
 		{
 			enableCommandUris: true,

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -18,6 +18,7 @@ import {log} from "./logging";
 const executionInfoPrefix = "### ";
 const defaultCodeBlockMaxInvocations = "unlimited";
 
+
 const stepPageHtmlPrefix = `
 <!DOCTYPE html>
 <html lang="en">
@@ -78,6 +79,7 @@ function parseCodeBlockContent(step: string, index: number, cbContent: string): 
         ls
     or
         ### myTermId
+		ls
     into a FullCommand object.
     Notes:
         - Codeblocks with no "### "-prefixed lines will just work
@@ -217,7 +219,8 @@ export function loadPage(target: TargetStep, env: KatapodEnvironment) {
 		const aSpanEleCloser = suppressExecution ? '</span>': '</a>';
 		const preEle = `<pre` + slf.renderAttrs(token) + `>`;
 		const codeEleClasses = suppressExecution ? "codeblock nonexecutable" : "codeblock executable";
-		const codeEle = `<code id="${parsedCommand.codeBlockId}" class="${codeEleClasses}">`;
+		const codeEleStyle = parsedCommand.backgroundColor ? ` style="background-color: ${parsedCommand.backgroundColor};"` : "";
+		const codeEle = `<code id="${parsedCommand.codeBlockId}" class="${codeEleClasses}"${codeEleStyle}>`;
 
 		return `${aSpanEle}${preEle}${codeEle}${renderedCode}</code></pre>${aSpanEleCloser}`;
 
@@ -252,9 +255,42 @@ export function loadPage(target: TargetStep, env: KatapodEnvironment) {
 		return imageDefault(tokens, idx, options, env, self);
 	};
 
+	// process tables
+	// (see https://github.com/markdown-it/markdown-it/blob/master/docs/examples/renderer_rules.md for the general procedure)
+	const tableTbProxy = (tokens: any, idx: any, options: any, env: any, self: any) => self.renderToken(tokens, idx, options);
+	const tableTbDefault = md.renderer.rules.table_open || tableTbProxy;
+	md.renderer.rules.table_open = function(tokens: any, idx: any, options: any, env: any, self: any) {
+	   // Make your changes here ...
+	   tokens[idx].attrJoin("class", "katapod-table");
+	   // ... then render it using the existing logic
+	   return tableTbDefault(tokens, idx, options, env, self);
+	};
+
+	const tableThProxy = (tokens: any, idx: any, options: any, env: any, self: any) => self.renderToken(tokens, idx, options);
+	const tableThDefault = md.renderer.rules.th_open || tableThProxy;
+	md.renderer.rules.th_open = function(tokens: any, idx: any, options: any, env: any, self: any) {
+	   // Make your changes here ...
+	   tokens[idx].attrJoin("class", "katapod-table");
+	   // ... then render it using the existing logic
+	   return tableThDefault(tokens, idx, options, env, self);
+	};
+
+	const tableTdProxy = (tokens: any, idx: any, options: any, env: any, self: any) => self.renderToken(tokens, idx, options);
+	const tableTdDefault = md.renderer.rules.td_open || tableTdProxy;
+	md.renderer.rules.td_open = function(tokens: any, idx: any, options: any, env: any, self: any) {
+	   // Make your changes here ...
+	   tokens[idx].attrJoin("class", "katapod-table");
+	   // ... then render it using the existing logic
+	   return tableTdDefault(tokens, idx, options, env, self);
+	};
+
+
 	var result = md.render((fs.readFileSync(file.fsPath, "utf8")));
 
 	env.components.panel.webview.html = stepPageHtmlPrefix + result + stepPageHtmlPostfix;
+
+	// quick local-run html debug
+	// fs.writeFileSync('rendered_katapod_page.html',stepPageHtmlPrefix + result + stepPageHtmlPostfix, 'utf8');
 
 	// process step-scripts, if present:
 	const stepScripts = (env.configuration.navigation?.onLoadCommands || {})[target.step] || {};

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -26,7 +26,7 @@ const stepPageHtmlPrefix = `
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.7.0/build/styles/default.min.css">
-		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/css/katapodv2.css" />
+		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/css/katapod.css" />
 		<script src="https://datastax-academy.github.io/katapod-shared-assets/js/katapod.js"></script>
 		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/quiz/quiz.css" />
 		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/quiz/page.css" />
@@ -265,25 +265,6 @@ export function loadPage(target: TargetStep, env: KatapodEnvironment) {
 	   // ... then render it using the existing logic
 	   return tableTbDefault(tokens, idx, options, env, self);
 	};
-
-	const tableThProxy = (tokens: any, idx: any, options: any, env: any, self: any) => self.renderToken(tokens, idx, options);
-	const tableThDefault = md.renderer.rules.th_open || tableThProxy;
-	md.renderer.rules.th_open = function(tokens: any, idx: any, options: any, env: any, self: any) {
-	   // Make your changes here ...
-	   tokens[idx].attrJoin("class", "katapod-table");
-	   // ... then render it using the existing logic
-	   return tableThDefault(tokens, idx, options, env, self);
-	};
-
-	const tableTdProxy = (tokens: any, idx: any, options: any, env: any, self: any) => self.renderToken(tokens, idx, options);
-	const tableTdDefault = md.renderer.rules.td_open || tableTdProxy;
-	md.renderer.rules.td_open = function(tokens: any, idx: any, options: any, env: any, self: any) {
-	   // Make your changes here ...
-	   tokens[idx].attrJoin("class", "katapod-table");
-	   // ... then render it using the existing logic
-	   return tableTdDefault(tokens, idx, options, env, self);
-	};
-
 
 	var result = md.render((fs.readFileSync(file.fsPath, "utf8")));
 

--- a/src/runCommands.ts
+++ b/src/runCommands.ts
@@ -20,6 +20,7 @@ export interface ConfigCommand {
 	execute?: boolean;
 	maxInvocations?: number | "unlimited";
 	macrosBefore?: Array<Macro>;
+	backgroundColor?: string;
 }
 // the above would become the following, with defaults and added stuff
 export interface FullCommand {
@@ -29,6 +30,7 @@ export interface FullCommand {
 	codeBlockId: string;
 	maxInvocations: number | "unlimited";
 	macrosBefore?: Array<Macro>;
+	backgroundColor?: string;
 }
 
 


### PR DESCRIPTION
Most of these rely on the newly-release css in the twin repo.

- (markdown) Table style handling
- collapsible-block styling
- support for arbitrary code-block background color
- changed generic title ("training grounds" -> "Hands-On Labs")